### PR TITLE
Add `isNowOrFuture()` and `isNowOrPast()` methods

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -2890,6 +2890,30 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     public static function isMutable(): bool;
 
     /**
+     * Determines if the instance is now or in the future, ie. greater (after) than or equal to now.
+     *
+     * @example
+     * ```
+     * Carbon::now()->isNowOrFuture(); // true
+     * Carbon::now()->addHours(5)->isNowOrFuture(); // true
+     * Carbon::now()->subHours(5)->isNowOrFuture(); // false
+     * ```
+     */
+    public function isNowOrFuture(): bool;
+
+    /**
+     * Determines if the instance is now or in the past, ie. less (before) than or equal to now.
+     *
+     * @example
+     * ```
+     * Carbon::now()->isNowOrPast(); // true
+     * Carbon::now()->subHours(5)->isNowOrPast(); // true
+     * Carbon::now()->addHours(5)->isNowOrPast(); // false
+     * ```
+     */
+    public function isNowOrPast(): bool;
+
+    /**
      * Determines if the instance is in the past, ie. less (before) than now.
      *
      * @example

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -461,6 +461,36 @@ trait Comparison
     }
 
     /**
+     * Determines if the instance is now or in the future, ie. greater (after) than or equal to now.
+     *
+     * @example
+     * ```
+     * Carbon::now()->isNowOrFuture(); // true
+     * Carbon::now()->addHours(5)->isNowOrFuture(); // true
+     * Carbon::now()->subHours(5)->isNowOrFuture(); // false
+     * ```
+     */
+    public function isNowOrFuture(): bool
+    {
+        return $this->greaterThanOrEqualTo($this->nowWithSameTz());
+    }
+
+    /**
+     * Determines if the instance is now or in the past, ie. less (before) than or equal to now.
+     *
+     * @example
+     * ```
+     * Carbon::now()->isNowOrPast(); // true
+     * Carbon::now()->subHours(5)->isNowOrPast(); // true
+     * Carbon::now()->addHours(5)->isNowOrPast(); // false
+     * ```
+     */
+    public function isNowOrPast(): bool
+    {
+        return $this->lessThanOrEqualTo($this->nowWithSameTz());
+    }
+
+    /**
      * Determines if the instance is a leap year.
      *
      * @example

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -240,6 +240,36 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::now()->isPast());
     }
 
+    public function testIsNowOrFutureTrue()
+    {
+        $this->assertTrue(Carbon::now()->addSecond()->isNowOrFuture());
+    }
+
+    public function testIsNowOrFutureFalse()
+    {
+        $this->assertFalse(Carbon::now()->subSecond()->isNowOrFuture());
+    }
+
+    public function testNowIsNowOrFutureTrue()
+    {
+        $this->assertTrue(Carbon::now()->isNowOrFuture());
+    }
+
+    public function testIsNowOrPastTrue()
+    {
+        $this->assertTrue(Carbon::now()->subSecond()->isNowOrPast());
+    }
+
+    public function testIsNowOrPastFalse()
+    {
+        $this->assertFalse(Carbon::now()->addSecond()->isNowOrPast());
+    }
+
+    public function testNowIsNowOrPastTrue()
+    {
+        $this->assertTrue(Carbon::now()->isNowOrPast());
+    }
+
     public function testIsLeapYearTrue()
     {
         $this->assertTrue(Carbon::createFromDate(2016, 1, 1)->isLeapYear());

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -237,6 +237,36 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::now()->isPast());
     }
 
+    public function testIsNowOrFutureTrue()
+    {
+        $this->assertTrue(Carbon::now()->addSecond()->isNowOrFuture());
+    }
+
+    public function testIsNowOrFutureFalse()
+    {
+        $this->assertFalse(Carbon::now()->subSecond()->isNowOrFuture());
+    }
+
+    public function testNowIsNowOrFutureTrue()
+    {
+        $this->assertTrue(Carbon::now()->isNowOrFuture());
+    }
+
+    public function testIsNowOrPastTrue()
+    {
+        $this->assertTrue(Carbon::now()->subSecond()->isNowOrPast());
+    }
+
+    public function testIsNowOrPastFalse()
+    {
+        $this->assertFalse(Carbon::now()->addSecond()->isNowOrPast());
+    }
+
+    public function testNowIsNowOrPastTrue()
+    {
+        $this->assertTrue(Carbon::now()->isNowOrPast());
+    }
+
     public function testIsLeapYearTrue()
     {
         $this->assertTrue(Carbon::createFromDate(2016, 1, 1)->isLeapYear());


### PR DESCRIPTION
## Why
Laravel recently introduced relative date shorthands to the Query Builder ([PR here](https://github.com/laravel/framework/pull/54408)). Some of these methods include `wherePast` and `whereFuture`. Along with these methods, `whereNowOrPast` and `whereNowOrFuture` were introduced. These have been really helpful when querying timestamps.

However, after using these new query methods, I keep finding myself reaching for `$carbon->isNowOrPast()` and `$carbon->isNowOrFuture()`, but they don't exist in Carbon. I would have assumed something like this would have been implemented in Carbon already.

After a bit of digging, I found that `isPast` used to be inclusive in that it was an inverse of `isFuture` and would be `true` for the current time. This was fixed more than 10 years ago in #142, and rightly so. However, I would like to bring back a bit of this functionality in two new methods.

## What
Added the following methods:
- `isNowOrFuture`: Copied `isFuture` but changed `greaterThan` to `greaterThanOrEqualTo`
- `isNowOrPast`: Copied `isPast` but changed `lessThan` to `lessThanOrEqualTo`

Added tests in both `tests/Carbon/IsTest.php` and `tests/CarbonImmutable/IsTest.php` based on existing `isFuture` and `isPast` tests.